### PR TITLE
Use typed arrays to speed up generating the output PNG stream

### DIFF
--- a/lib/pnglib.js
+++ b/lib/pnglib.js
@@ -81,7 +81,7 @@
     this.iend_size = 4 + 4 + 4;
     this.buffer_size  = this.iend_offs + this.iend_size;	// total PNG size
 
-    this.buffer  = [];
+    this.buffer  = new Uint8Array(this.buffer_size);
     this.palette = {};
     this.pindex  = 0;
 

--- a/lib/pnglib.js
+++ b/lib/pnglib.js
@@ -73,7 +73,7 @@
     this.iend_size = 4 + 4 + 4;
     this.buffer_size  = this.iend_offs + this.iend_size;	// total PNG size
 
-    this.buffer  = new Array();
+    this.buffer  = new Uint8Array();
     this.palette = new Object();
     this.pindex  = 0;
 
@@ -175,8 +175,13 @@
         return r;
     }
 
-    // output a PNG string
-    this.getDump = function() {
+    this.getPNGBuffer = function() {
+    
+      var MAGIC_STR = "\x89PNG\r\n\x1a\n".split('');
+      var MAGIC_HDR = new Uint8Array(MAGIC_STR.length);
+      for (var i = 0; i < MAGIC_STR.length; i++) {
+        MAGIC_HDR[i] = MAGIC_STR.charCodeAt(i);
+      }
 
         // compute adler32 of output pixels + row filter bytes
         var BASE = 65521; /* largest prime smaller than 65536 */
@@ -216,7 +221,11 @@
         crc32(this.buffer, this.iend_offs, this.iend_size);
 
         // convert PNG to string
-        return "\x89PNG\r\n\x1a\n" + this.buffer.join('');
+        return MAGIC_HDR.concat(this.buffer);
     }
+    
+    this.getDump() = function() {
+      return this.getPNGBuffer().join('');
+    };
 });
 

--- a/lib/pnglib.js
+++ b/lib/pnglib.js
@@ -33,21 +33,29 @@
     function write(buffer, offs) {
         for (var i = 2; i < arguments.length; i++) {
             for (var j = 0; j < arguments[i].length; j++) {
-                buffer[offs++] = arguments[i].charAt(j);
+                buffer[offs++] = arguments[i][j];
             }
         }
     }
 
     function byte2(w) {
-        return String.fromCharCode((w >> 8) & 255, w & 255);
+        return [(w >> 8) & 255, w & 255];
     }
 
     function byte4(w) {
-        return String.fromCharCode((w >> 24) & 255, (w >> 16) & 255, (w >> 8) & 255, w & 255);
+        return [(w >> 24) & 255, (w >> 16) & 255, (w >> 8) & 255, w & 255];
     }
 
     function byte2lsb(w) {
-        return String.fromCharCode(w & 255, (w >> 8) & 255);
+        return [w & 255, (w >> 8) & 255];
+    }
+    
+    function strbuf(s) {
+      var buf = new Uint8Array(s.length);
+      for (var i = 0; i < s.length; i++) {
+        buf[i] = s.charCodeAt(i);
+      }
+      return buf;
     }
 
     this.width   = width;
@@ -73,23 +81,18 @@
     this.iend_size = 4 + 4 + 4;
     this.buffer_size  = this.iend_offs + this.iend_size;	// total PNG size
 
-    this.buffer  = new Uint8Array();
-    this.palette = new Object();
+    this.buffer  = [];
+    this.palette = {};
     this.pindex  = 0;
 
     var _crc32 = new Array();
 
-    // initialize buffer with zero bytes
-    for (var i = 0; i < this.buffer_size; i++) {
-        this.buffer[i] = "\x00";
-    }
-
     // initialize non-zero elements
-    write(this.buffer, this.ihdr_offs, byte4(this.ihdr_size - 12), 'IHDR', byte4(width), byte4(height), "\x08\x03");
-    write(this.buffer, this.plte_offs, byte4(this.plte_size - 12), 'PLTE');
-    write(this.buffer, this.trns_offs, byte4(this.trns_size - 12), 'tRNS');
-    write(this.buffer, this.idat_offs, byte4(this.idat_size - 12), 'IDAT');
-    write(this.buffer, this.iend_offs, byte4(this.iend_size - 12), 'IEND');
+    write(this.buffer, this.ihdr_offs, byte4(this.ihdr_size - 12), strbuf('IHDR'), byte4(width), byte4(height), [8, 3]);
+    write(this.buffer, this.plte_offs, byte4(this.plte_size - 12), strbuf('PLTE'));
+    write(this.buffer, this.trns_offs, byte4(this.trns_size - 12), strbuf('tRNS'));
+    write(this.buffer, this.idat_offs, byte4(this.idat_size - 12), strbuf('IDAT'));
+    write(this.buffer, this.iend_offs, byte4(this.iend_size - 12), strbuf('IEND'));
 
     // initialize deflate header
     var header = ((8 + (7 << 4)) << 8) | (3 << 6);
@@ -102,12 +105,12 @@
         var size, bits;
         if (i + 0xffff < this.pix_size) {
             size = 0xffff;
-            bits = "\x00";
+            bits = 0;
         } else {
             size = this.pix_size - (i << 16) - i;
-            bits = "\x01";
+            bits = 1;
         }
-        write(this.buffer, this.idat_offs + 8 + 2 + (i << 16) + (i << 2), bits, byte2lsb(size), byte2lsb(~size));
+        write(this.buffer, this.idat_offs + 8 + 2 + (i << 16) + (i << 2), [bits], byte2lsb(size), byte2lsb(~size));
     }
 
     /* Create crc32 lookup table */
@@ -137,16 +140,16 @@
         var color = (((((alpha << 8) | red) << 8) | green) << 8) | blue;
 
         if (typeof this.palette[color] == "undefined") {
-            if (this.pindex == this.depth) return "\x00";
+            if (this.pindex == this.depth) return 0;
 
             var ndx = this.plte_offs + 8 + 3 * this.pindex;
 
-            this.buffer[ndx + 0] = String.fromCharCode(red);
-            this.buffer[ndx + 1] = String.fromCharCode(green);
-            this.buffer[ndx + 2] = String.fromCharCode(blue);
-            this.buffer[this.trns_offs+8+this.pindex] = String.fromCharCode(alpha);
+            this.buffer[ndx + 0] = Math.floor(red);
+            this.buffer[ndx + 1] = Math.floor(green);
+            this.buffer[ndx + 2] = Math.floor(blue);
+            this.buffer[this.trns_offs+8+this.pindex] = Math.floor(alpha);
 
-            this.palette[color] = String.fromCharCode(this.pindex++);
+            this.palette[color] = this.pindex++;
         }
         return this.palette[color];
     }
@@ -154,7 +157,7 @@
     // output a PNG string, Base64 encoded
     this.getBase64 = function() {
 
-        var s = this.getDump();
+        var s = this.getPNGBuffer();
 
         var ch = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
         var c1, c2, c3, e1, e2, e3, e4;
@@ -163,11 +166,11 @@
         var r = "";
 
         do {
-            c1 = s.charCodeAt(i);
+            c1 = s[i];
             e1 = c1 >> 2;
-            c2 = s.charCodeAt(i+1);
+            c2 = s[i+1];
             e2 = ((c1 & 3) << 4) | (c2 >> 4);
-            c3 = s.charCodeAt(i+2);
+            c3 = s[i+2];
             if (l < i+2) { e3 = 64; } else { e3 = ((c2 & 0xf) << 2) | (c3 >> 6); }
             if (l < i+3) { e4 = 64; } else { e4 = c3 & 0x3f; }
             r+= ch.charAt(e1) + ch.charAt(e2) + ch.charAt(e3) + ch.charAt(e4);
@@ -177,11 +180,7 @@
 
     this.getPNGBuffer = function() {
     
-      var MAGIC_STR = "\x89PNG\r\n\x1a\n".split('');
-      var MAGIC_HDR = new Uint8Array(MAGIC_STR.length);
-      for (var i = 0; i < MAGIC_STR.length; i++) {
-        MAGIC_HDR[i] = MAGIC_STR.charCodeAt(i);
-      }
+      var MAGIC_STR = [ 137, 80, 78, 71, 13, 10, 26, 10 ];
 
         // compute adler32 of output pixels + row filter bytes
         var BASE = 65521; /* largest prime smaller than 65536 */
@@ -192,7 +191,7 @@
 
         for (var y = 0; y < this.height; y++) {
             for (var x = -1; x < this.width; x++) {
-                s1+= this.buffer[this.index(x, y)].charCodeAt(0);
+                s1+= this.buffer[this.index(x, y)];
                 s2+= s1;
                 if ((n-= 1) == 0) {
                     s1%= BASE;
@@ -209,7 +208,7 @@
         function crc32(png, offs, size) {
             var crc = -1;
             for (var i = 4; i < size-4; i += 1) {
-                crc = _crc32[(crc ^ png[offs+i].charCodeAt(0)) & 0xff] ^ ((crc >> 8) & 0x00ffffff);
+                crc = _crc32[(crc ^ png[offs+i]) & 0xff] ^ ((crc >> 8) & 0x00ffffff);
             }
             write(png, offs+size-4, byte4(crc ^ -1));
         }
@@ -220,12 +219,13 @@
         crc32(this.buffer, this.idat_offs, this.idat_size);
         crc32(this.buffer, this.iend_offs, this.iend_size);
 
-        // convert PNG to string
-        return MAGIC_HDR.concat(this.buffer);
+        // Allocate a new buffer to return
+        var rbuf = new Uint8Array(MAGIC_STR.length + this.buffer.length);
+        // Add the magic string at the start of the buffer
+        rbuf.set(MAGIC_STR, 0);
+        // Then add the working buffer to the return buffer after the magic string
+        rbuf.set(this.buffer, MAGIC_STR.length);
+        return rbuf;
     }
-    
-    this.getDump() = function() {
-      return this.getPNGBuffer().join('');
-    };
 });
 


### PR DESCRIPTION
This uses new typed arrays (specifically Uint8Array) to speed up the library. Most of the speedup comes from pre-allocating the array with the length calculated earlier which prevents resizing, and some comes from the new getPNGBuffer() method which simply returns a buffer with the PNG data inside. At the same time, getDump() has been removed. getBase64() still works.
